### PR TITLE
Fix Winit link in README by adding missing https

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ JavaFX:
 - VSync is weird in multi-monitor case
 - No real extensibility
 
-[Winit](github.com/rust-windowing/winit):
+[Winit](https://github.com/rust-windowing/winit):
 
 - Tried at JetBrains
 - Complicated event loop model (tries to unify desktop + web + mobile)


### PR DESCRIPTION
Original link in README did not specify protocol, was falsely treated as a relative link.